### PR TITLE
fix BaseModel.Propagate() implementation

### DIFF
--- a/sim/model.go
+++ b/sim/model.go
@@ -67,7 +67,7 @@ func NewBaseModel(A, B, C, D, E *mat.Dense, dt float64) (*BaseModel, error) {
 	if dt <= 0 {
 		return nil, fmt.Errorf("time step may not be zero or less than zero")
 	}
-	return &BaseModel{A: A, B: B, C: C, D: D, E: E}, nil
+	return &BaseModel{A: A, B: B, C: C, D: D, E: E, Dt: dt}, nil
 }
 
 // Propagate propagates returns the next internal state x

--- a/sim/model_test.go
+++ b/sim/model_test.go
@@ -62,7 +62,7 @@ func TestInitCond(t *testing.T) {
 func TestBase(t *testing.T) {
 	assert := assert.New(t)
 
-	f, err := NewBaseModel(A, B, C, D, E)
+	f, err := NewBaseModel(A, B, C, D, E, 1.)
 	assert.NotNil(f)
 	assert.NoError(err)
 }
@@ -70,7 +70,7 @@ func TestBase(t *testing.T) {
 func TestBasePropagate(t *testing.T) {
 	assert := assert.New(t)
 
-	f, err := NewBaseModel(A, B, C, D, E)
+	f, err := NewBaseModel(A, B, C, D, E, 1.)
 	assert.NotNil(f)
 	assert.NoError(err)
 
@@ -96,7 +96,7 @@ func TestBasePropagate(t *testing.T) {
 func TestBaseObserve(t *testing.T) {
 	assert := assert.New(t)
 
-	f, err := NewBaseModel(A, B, C, D, E)
+	f, err := NewBaseModel(A, B, C, D, E, 1.)
 	assert.NotNil(f)
 	assert.NoError(err)
 
@@ -122,7 +122,7 @@ func TestBaseObserve(t *testing.T) {
 func TestBaseSystemMatrices(t *testing.T) {
 	assert := assert.New(t)
 
-	f, err := NewBaseModel(A, B, C, D, E)
+	f, err := NewBaseModel(A, B, C, D, E, 1.)
 	assert.NotNil(f)
 	assert.NoError(err)
 
@@ -142,7 +142,7 @@ func TestBaseSystemMatrices(t *testing.T) {
 func TestBaseDims(t *testing.T) {
 	assert := assert.New(t)
 
-	f, err := NewBaseModel(A, B, C, D, E)
+	f, err := NewBaseModel(A, B, C, D, E, 1.)
 	assert.NotNil(f)
 	assert.NoError(err)
 


### PR DESCRIPTION
I found a rather serious mistake in the implementation of `Propagate()`.

The issue is that next state was calculated as `X_{n+1} = A*X_{n} + B*U`. The equation modern control theory supposes is `dX/dt = A * X_{n} + B*U` which means you have to integrate the result in time.